### PR TITLE
feat: #30 SVG 컴포넌트 지원을 위한 webpack 설정 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,13 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: ['@svgr/webpack'],
+    });
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@eslint/js": "^9.19.0",
+    "@svgr/webpack": "^8.1.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/public/assets/icons/header_back.svg
+++ b/public/assets/icons/header_back.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="19" viewBox="0 0 11 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.48535 1L1.00007 9.48528L9.48535 17.9706" stroke="#909090" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
#### 📌 PR 전 체크 사항

- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] feature 브랜치에서 작업 하셨나요?

## 📒 작업 내용
- svgr를 추가했습니다.

### 📸 스크린샷 (선택)

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...
1. svg로 만들어도 될 것 같은 요소는 svg를 활용합니다.
2. public/ assets/icons 폴더 위치에 소문자로 svg파일을 추가합니다.
3. 사용예시
```tsx
import BackIcon from '/public/assets/icons/header_back.svg';

export default function Home() {
  return (
    <div>
      <BackIcon /> // props로 사이즈, 색상을 변경할 수 있습니다.
    </div>
  );
}
```


## ✔ 이슈 번호
ex) close #{번호}
close #30 
