### PR TITLE
feat: #50 큰버튼, 작은버튼 컴포넌트 구현

### DIFF
--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,0 +1,45 @@
+import { ButtonHTMLAttributes } from 'react';
+
+import { cn } from '@/utils/cn';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: 'large' | 'small';
+  variant?: 'filled' | 'outline' | 'disabled';
+  isSelected?: boolean;
+}
+
+const SIZE = {
+  large: 'w-full h-[52px] rounded-[14px]',
+  small: 'w-[55px] h-[35px] rounded-full',
+};
+
+const VARIANTS = {
+  filled: 'bg-gradient-to-r from-mainPink1 to-mainPink2 text-white',
+  outline: 'border-2 text-mainPink1 border-mainPink1',
+  disabled: 'border-2 text-gray1 border-gray-1',
+};
+
+export default function Button({
+  size = 'small',
+  variant = 'disabled',
+  isSelected = false,
+  className,
+  children,
+  ...restProps
+}: ButtonProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'text-[16px] font-semiBold',
+        SIZE[size],
+        VARIANTS[variant],
+        isSelected && 'ring-2 ring-mainPink1',
+        className,
+      )}
+      {...restProps}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
#### 📌 PR 전 체크 사항

- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] feature 브랜치에서 작업 하셨나요?

## 📒 작업 내용
- 큰 버튼 컴포넌트 구현
- 작은 버튼 컴포넌트 구현

### 📸 스크린샷 (선택)
<img width="371" alt="버튼 컴포넌트" src="https://github.com/user-attachments/assets/7f195f04-6357-4a9c-bc16-7776b3e2b9af" />

## 📢 리뷰어에게 하고 싶은 말

ex) 어디어디를 중점적으로 봐주세요 ...

은지님이 작업하신 chip 버튼 컴포넌트 코드 참조해서 구현했습니다!

버튼의 호버 디자인을 명확하게 구분하지 못해 tailwind ring으로 임시 구현했습니당

## ✔ 이슈 번호

ex) close #{번호}
close #50 